### PR TITLE
Fix sqlitevec loading on Android

### DIFF
--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -25,6 +25,14 @@ add_library(${LIBRARY_NAME} SHARED
         ${SQLITE_SOURCES_DIR}/sqlite-vec.c
 )
 
+# Build sqlite-vec directly into SQLite and enable extension support
+target_compile_definitions(
+    ${LIBRARY_NAME}
+    PRIVATE
+    SQLITE_CORE
+    SQLITE_OMIT_LOAD_EXTENSION=0
+)
+
 # --- Compile Definitions for SQLite (Optional but often needed) ---
 # Refer to SQLite and sqlite-vec documentation if you encounter issues or need
 # specific features enabled. For example, if sqlite-vec requires specific


### PR DESCRIPTION
## Summary
- compile sqlitevec directly into the Android library

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846059542708321b72520cee9acc749